### PR TITLE
GambleManager 리팩토링

### DIFF
--- a/Assets/Polygon Arsenal/Upgrades/Polygon Arsenal 2019.4 URP.unitypackage.meta
+++ b/Assets/Polygon Arsenal/Upgrades/Polygon Arsenal 2019.4 URP.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 722b345e75819a746b29fa3a60388496
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Common/PlayerInfo.cs
+++ b/Assets/Scripts/Common/PlayerInfo.cs
@@ -48,6 +48,11 @@ public class PlayerInfo
         coins += _coins;
     }
 
+    public void Win()
+    {
+        AddCoin(challengeAmount);
+    }
+
     public void Dead()
     {
         isLive = false;

--- a/Assets/Scripts/Common/PlayerInfo.cs
+++ b/Assets/Scripts/Common/PlayerInfo.cs
@@ -69,7 +69,7 @@ public class PlayerInfo
         return IsChallenge() && challengeAmount <= potCoins; 
     }
 
-    public bool IsDecide()
+    public bool IsDecided()
     {
         return choice != Choice.none;
     }

--- a/Assets/Scripts/Common/PlayerInfo.cs
+++ b/Assets/Scripts/Common/PlayerInfo.cs
@@ -1,22 +1,96 @@
 public class PlayerInfo
 {
-    const int ATTACK_CHANCE = 1;
-    public bool isLive{get; set;} = true;
-    public bool canShoot{get; set;} = false;
-    public int coins{get; set;} = 0;
-    public int attackChance{get; set;} = ATTACK_CHANCE;
-    public Choice choice{get; set;} = Choice.none;
-    public int challengeAmount{get;set;} = 0;
+    public bool isLive { get; private set; }
+    public int coins { get; private set; }
+    public Choice choice { get; private set; }
+    public int challengeAmount { get; private set; }
+    public bool canShoot { get; private set; }
+    public int attackChance { get; private set; }
 
-    public int actorNumber{get; private set;}
+    public int actorNumber { get; private set; }
     
     public PlayerInfo()
     {
         actorNumber = -1;
+        Reset();
     }
 
-    public PlayerInfo(int aNum)
+    public PlayerInfo(int _actorNumber)
     {
-        actorNumber = aNum;
+        actorNumber = _actorNumber;
+        Reset();
+    }
+
+    public void Reset()
+    {
+        isLive = true;
+        coins = 0;
+        choice = Choice.none;
+        challengeAmount = 0;
+        canShoot = false;
+        attackChance = 1;
+    }
+
+    public void SuccessChoiceAttack()
+    {
+        canShoot = true;
+    }
+
+    public void Attack(PlayerInfo target)
+    {
+        attackChance--;
+        coins += target.coins;
+        target.Dead();
+    }
+
+    public void AddCoin(int _coins)
+    {
+        coins += _coins;
+    }
+
+    public void Dead()
+    {
+        isLive = false;
+        choice = Choice.none;
+    }
+
+    public void ChoiceShare()
+    {
+        choice = Choice.share;
+    }
+
+    public bool IsChallengeSuccess(int potCoins)
+    {
+        return IsChallenge() && challengeAmount <= potCoins; 
+    }
+
+    public bool IsDecide()
+    {
+        return choice != Choice.none;
+    }
+
+    public bool IsChallenge()
+    {
+        return choice == Choice.challenge;
+    }
+
+    public bool IsAttack()
+    {
+        return choice == Choice.attack;
+    }
+
+    public bool IsShare()
+    {
+        return choice == Choice.share;
+    }
+
+    public void SetChoice(Choice _choice)
+    {
+        choice = _choice;
+    }
+
+    public void SetChallengeAmount(int amount)
+    {
+        challengeAmount = amount;
     }
 }

--- a/Assets/Scripts/Gamble/GambleManager.cs
+++ b/Assets/Scripts/Gamble/GambleManager.cs
@@ -10,9 +10,7 @@ public class GambleManager : MonoBehaviour
     void Awake()
     {
         instance = this;
-        challengeWinner = null;
-        attackWinner = null;
-        victim = null;
+
         round = 1;
         act = 1;
         potCoins = 0;
@@ -23,7 +21,7 @@ public class GambleManager : MonoBehaviour
         localPlayer = null;
 
         //싱글플레이 위한 초기화
-        playerList.Add(new PlayerInfo(PhotonNetwork.LocalPlayer.ActorNumber));
+        players.Add(PhotonNetwork.LocalPlayer.ActorNumber);
     }
 
     const int MAX_DECIDE_TIME = 60, MAX_ATTACK_TIME = 60;
@@ -34,230 +32,15 @@ public class GambleManager : MonoBehaviour
     public static State state { get; private set; }
 
     public static GamblePlayer localPlayer {get; private set;}
-    public static PlayerInfo localPlayerInfo { get; private set; }
 
-    static List<PlayerInfo> playerList = new List<PlayerInfo>();
-    static PlayerInfo challengeWinner, attackWinner, victim;
+    private static PlayerInfoList players = new PlayerInfoList();
 
     public static int round { get; private set; }
     public static int act { get; private set; }
     public static int potCoins { get; private set; }
-    public static int chestCoins {get; set; }
+    public static int chestCoins { get; set; }
     public static float leftTime { get; private set; }
     float coinTime;
-
-    void StandBy()
-    {
-        if (localPlayer == null) return;
-        Debug.Log(localPlayer);
-        ResetPlayerInfoList();
-        potCoins += GetPotCoins();
-        leftTime = MAX_DECIDE_TIME;
-        state = State.decide;
-        localPlayer.SpawnMedals();
-    }
-    void Decide()
-    {
-        if (leftTime > 0)
-        {
-            foreach (var p in playerList)
-            {
-                if (p.choice == Choice.none)
-                {
-                    leftTime -= Time.deltaTime;
-                    return;
-                }
-            }
-        }
-        else
-        {
-            foreach (var p in playerList)
-                if (p.choice == Choice.none) p.choice = Choice.share;
-        }
-        state = State.check;
-    }
-    void Check()
-    {
-        localPlayer.DestroyMedals();
-        SetChallengeWinner();
-        SetAttackWinner();
-        state = State.apply;
-    }
-    void Attack()
-    {
-        if (!attackWinner.canShoot || leftTime > 0)
-        {
-            leftTime -= Time.deltaTime;
-        }
-        else state = State.apply;
-        //if kill?
-        //사격 시 대상이 플레이어인 경우
-        { victim = playerList[4]; }
-        attackWinner.canShoot = false;
-        attackWinner.attackChance--;
-
-    }
-    void Apply()
-    {
-        SetPlayerRewards();
-        //네트워크에 각자 T 결과에 따라 처리하도록 전송
-        if (MAX_ROUND <= round && MAX_ACT <= act)
-        {
-            state = State.end;
-            return;
-        }
-        int winCoins = localPlayerInfo.coins - localPlayer.coinSpawner.transform.childCount - chestCoins;
-        localPlayer.AddCoins(winCoins);
-        state = State.standBy;
-        if (act % MAX_ACT == 0)
-            round++;
-        act = (act % MAX_ACT) + 1;
-    }
-
-    //Player Input
-    public static void SetLocalPlayer(GamblePlayer player)
-    {
-        int aNum = PhotonNetwork.LocalPlayer.ActorNumber;
-        localPlayer = player;
-        //localPlayerInfo = GetPlayerInfo(aNum);
-        localPlayerInfo = playerList[0];
-        state = State.standBy;
-    }
-    public static void SetPlayerChoice(Choice choice)
-    {
-        if (localPlayerInfo != null)
-            localPlayerInfo.choice = choice;
-        else Debug.Log("localPlayer is null!");
-    }
-    public static void SetPlayerChallengeAmount(int amount)
-    {
-        if (localPlayerInfo != null)
-            localPlayerInfo.challengeAmount = amount;
-        else Debug.Log("localPlayer is null!");
-    }
-
-    //Network PlayerInfo
-    public static void SetPlayerList(string orArray)
-    {
-        //미구현
-        int aNum = 0;//임의의 액터넘버
-        playerList.Add(new PlayerInfo(aNum));
-        state = State.standBy;
-    }
-    public static void SetPlayerInfo(int aNum, string data)
-    {
-        PlayerInfo player = playerList.Find(p => p.actorNumber == aNum);
-        //json 파싱
-    }
-    public static PlayerInfo GetPlayerInfo(int aNum)
-    {
-        return playerList.Find(p => p.actorNumber == aNum);
-    }
-    //StandBy State
-    static void ResetPlayerInfoList()
-    {
-        foreach (var p in playerList)
-        {
-            p.choice = Choice.none;
-            p.challengeAmount = 0;
-            p.canShoot = false;
-        }
-        victim = null;
-        challengeWinner = null;
-        attackWinner = null;
-    }
-
-    public static int GetMinPotCoins()
-    {
-        int weight = (int)Mathf.Pow(POT_WEIGHT, round - 1);
-        return weight * 10;
-    }
-    public static int GetMaxPotCoins()
-    {
-        return GetMinPotCoins() * (round + 1);
-    }
-    int GetPotCoins()
-    {
-        return Random.Range(GetMinPotCoins(), GetMaxPotCoins());
-    }
-    bool IsInPotRange(int amount)
-    {
-        if (GetMinPotCoins() <= amount)
-        {
-            if (GetMaxPotCoins() >= amount)
-                return true;
-        }
-        return false;
-    }
-
-    //Check State
-    void SetChallengeWinner()
-    {
-        challengeWinner = null;
-        List<PlayerInfo> list = (from p in playerList
-                                 where p.choice == Choice.challenge && IsInPotRange(p.challengeAmount)
-                                 select p).ToList<PlayerInfo>();
-
-        if (list.Count > 0)
-        {
-            int maxAmount = list.Max(p => p.challengeAmount);
-            challengeWinner = list.Find(p => p.challengeAmount == maxAmount);
-        }
-    }
-
-    void SetAttackWinner()
-    {
-        attackWinner = null;
-
-        var list = (from p in playerList
-                    where p.choice == Choice.attack
-                    select p).ToList<PlayerInfo>();
-
-        if (list.Count == 1)
-        {
-            attackWinner = list.Find(p => p.choice == Choice.attack);
-            state = State.attack;
-        }
-
-    }
-
-    //Apply State
-    void KillPlayer(PlayerInfo victim)
-    {
-        if (victim == null) return;
-        attackWinner.coins += victim.coins;
-        victim.coins = 0;
-        victim.isLive = false;
-    }
-
-    int SharePlayer()
-    {
-        var list = (from p in playerList
-                    where p.choice == Choice.share
-                    && p.isLive
-                    select p).ToList<PlayerInfo>();
-
-        foreach (var p in list)
-        {
-            p.coins += potCoins / list.Count;
-        }
-
-        if (list.Count > 0)
-            return potCoins % list.Count;
-
-        return 0;
-    }
-
-    void SetPlayerRewards()
-    {
-        KillPlayer(victim);
-        if (challengeWinner != null)
-        {
-            challengeWinner.coins += challengeWinner.challengeAmount;
-            potCoins -= challengeWinner.challengeAmount;
-        }
-        potCoins = SharePlayer();
-    }
 
     // Update is called once per frame
     void Update()
@@ -272,7 +55,133 @@ public class GambleManager : MonoBehaviour
             case State.apply: Apply(); coinTime = 0; break;
             case State.end: break;
         }
-        coinTime+= Time.deltaTime;
-        if(coinTime > 5f) localPlayer.RemoveCoins();
+        coinTime += Time.deltaTime;
+        if (coinTime > 5f) localPlayer.RemoveCoins();
+    }
+
+    private void StandBy()
+    {
+        if (localPlayer == null) return;
+        Debug.Log(localPlayer);
+
+        players.Reset();
+        potCoins += GetPotCoins();
+        leftTime = MAX_DECIDE_TIME;
+        state = State.decide;
+        localPlayer.SpawnMedals();
+    }
+
+    private int GetPotCoins()
+    {
+        return Random.Range(GetMinPotCoins(), GetMaxPotCoins());
+    }
+
+    private int GetMinPotCoins()
+    {
+        int weight = (int)Mathf.Pow(POT_WEIGHT, round - 1);
+        return weight * 10;
+    }
+
+    private int GetMaxPotCoins()
+    {
+        return GetMinPotCoins() * (round + 1);
+    }
+
+
+    private void Decide()
+    {
+        if (leftTime > 0)
+        {
+            if (!players.EveryDecided())
+            {
+                leftTime -= Time.deltaTime;
+                return;
+            }
+        }
+        else
+        {
+            players.ChangeUndecidedPlayerToShare();
+        }
+        state = State.check;
+    }
+
+    private void Check()
+    {
+        localPlayer.DestroyMedals();
+        players.DecideChallengeWinners(potCoins);
+        players.DecideAttackWinner();
+        PlayerInfo attacker = players.GetAttackWinner();
+        if (attacker != null)
+        {
+            attacker.SuccessChoiceAttack();
+            state = State.attack;
+            return;
+        }
+        state = State.apply;
+    }
+
+    private void Attack()
+    {
+        PlayerInfo attacker = players.GetAttackWinner();
+        if (!attacker.canShoot || leftTime > 0)
+        {
+            leftTime -= Time.deltaTime;
+        }
+        else state = State.apply;
+        //if kill?
+        //사격 시 대상이 플레이어인 경우
+        PlayerInfo target = new PlayerInfo();
+        attacker.Attack(target);
+    }
+
+    private void Apply()
+    {
+        SetPlayerRewards();
+        //네트워크에 각자 T 결과에 따라 처리하도록 전송
+        if (MAX_ROUND <= round && MAX_ACT <= act)
+        {
+            state = State.end;
+            return;
+        }
+        int winCoins = players.GetMine().coins - localPlayer.coinSpawner.transform.childCount - chestCoins;
+        localPlayer.AddCoins(winCoins);
+        state = State.standBy;
+        if (act % MAX_ACT == 0)
+            round++;
+        act = (act % MAX_ACT) + 1;
+    }
+
+    private void SetPlayerRewards()
+    {
+        List<PlayerInfo> challengeWinners = players.GetChallengeWinners();
+        if (challengeWinners.Count > 0)
+        {
+            int winnerCoins = challengeWinners.First().coins / challengeWinners.Count;
+            challengeWinners.ForEach(winner => winner.AddCoin(winnerCoins));
+            potCoins -= winnerCoins;
+        }
+        players.ShareCoins(potCoins);
+        potCoins %= players.Count();
+    }
+
+
+    public static void SetLocalPlayer(GamblePlayer player)
+    {
+        localPlayer = player;
+    }
+
+    public static void SetPlayerChoice(Choice choice)
+    {
+        players.GetMine().SetChoice(choice);
+    }
+
+    public static void SetPlayerChallengeAmount(int amount)
+    {
+        players.GetMine().SetChallengeAmount(amount);
+    }
+
+    public static PlayerInfo GetMyInfo()
+    {
+        return players.GetMine();
     }
 }

--- a/Assets/Scripts/Gamble/GambleManager.cs
+++ b/Assets/Scripts/Gamble/GambleManager.cs
@@ -92,7 +92,6 @@ public class GambleManager : MonoBehaviour
         return GetMinPotCoins() * (round + 1);
     }
 
-
     private void Decide()
     {
         if (leftTime > 0)
@@ -128,15 +127,15 @@ public class GambleManager : MonoBehaviour
     private void Attack()
     {
         PlayerInfo attacker = players.GetAttackWinner();
-        if (!attacker.canShoot || leftTime > 0)
+        if (attacker.canShoot && leftTime > 0)
         {
             leftTime -= Time.deltaTime;
+            return;
         }
-        else state = State.apply;
-        //if kill?
-        //사격 시 대상이 플레이어인 경우
-        PlayerInfo target = new PlayerInfo();
-        attacker.Attack(target);
+        // 다른 곳에서 attacker.Attack(target)을 실행시켜야함
+        // PlayerInfo target = new PlayerInfo();
+        // attacker.Attack(target);
+        state = State.apply;
     }
 
     private void Apply()

--- a/Assets/Scripts/Gamble/GambleManager.cs
+++ b/Assets/Scripts/Gamble/GambleManager.cs
@@ -45,6 +45,11 @@ public class GambleManager : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        if (state == State.initial) {
+            if (players.Count() == PhotonNetwork.CurrentRoom.PlayerCount){
+                state = State.standBy;
+            }
+        }
         Debug.Log(state);
         switch (state)
         {

--- a/Assets/Scripts/Gamble/GambleManager.cs
+++ b/Assets/Scripts/Gamble/GambleManager.cs
@@ -158,12 +158,11 @@ public class GambleManager : MonoBehaviour
 
     private void SetPlayerRewards()
     {
-        List<PlayerInfo> challengeWinners = players.GetChallengeWinners();
-        if (challengeWinners.Count > 0)
+        PlayerInfo challengeWinner = players.GetChallengeWinner();
+        if (challengeWinner != null && challengeWinner.isLive)
         {
-            int winnerCoins = challengeWinners.First().coins / challengeWinners.Count;
-            challengeWinners.ForEach(winner => winner.AddCoin(winnerCoins));
-            potCoins -= winnerCoins;
+            challengeWinner.Win();
+            potCoins -= challengeWinner.challengeAmount;
         }
         players.ShareCoins(potCoins);
         potCoins %= players.Count();

--- a/Assets/Scripts/Gamble/PlayerInfoList.cs
+++ b/Assets/Scripts/Gamble/PlayerInfoList.cs
@@ -1,0 +1,78 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Photon.Pun;
+
+
+public class PlayerInfoList
+{
+    private List<PlayerInfo> players = new List<PlayerInfo>();
+    private List<PlayerInfo> winners = new List<PlayerInfo>();
+    private PlayerInfo attacker = null;
+
+    public void Add(int actorNumber)
+    {
+        players.Add(new PlayerInfo(actorNumber));
+    }
+
+    public void Reset()
+    {
+        players.ForEach(player => player.Reset());
+    }
+
+    public bool EveryDecided()
+    {
+        return players.TrueForAll(player => player.IsDecide());
+    }
+
+    public void ChangeUndecidedPlayerToShare()
+    {
+        players.FindAll(player => player.isLive && !player.IsDecide())
+            .ForEach(player => player.ChoiceShare());
+    }
+
+    public void DecideChallengeWinners(int potCoins)
+    {
+        List<PlayerInfo> challengers = players.FindAll(player => player.IsChallengeSuccess(potCoins));
+        int winnerAmount = challengers.Max(player => player.challengeAmount);
+        winners = challengers.FindAll(player => player.challengeAmount == winnerAmount);
+    }
+
+    public void DecideAttackWinner()
+    {
+        attacker = null;
+        List<PlayerInfo> attackers = players.FindAll(player => player.IsAttack());
+        if (attackers.Count != 1) return;
+        attacker = attackers.First();
+    }
+
+    public void ShareCoins(int potCoins)
+    {
+        List<PlayerInfo> sharer = players.FindAll(player => player.IsShare());
+        if (sharer.Count == 0) return;
+
+        int sharedCoins = potCoins / sharer.Count;
+        sharer.ForEach(player => player.AddCoin(sharedCoins));
+    }
+
+    public PlayerInfo GetMine()
+    {
+        int actorNumber = PhotonNetwork.LocalPlayer.ActorNumber;
+        return players.Find(player => player.actorNumber == actorNumber);
+    }
+
+    public int Count()
+    {
+        return players.Count;
+    }
+
+    public List<PlayerInfo> GetChallengeWinners()
+    {
+        return winners;
+    }
+
+    public PlayerInfo GetAttackWinner()
+    {
+        return attacker;
+    }
+}

--- a/Assets/Scripts/Gamble/PlayerInfoList.cs
+++ b/Assets/Scripts/Gamble/PlayerInfoList.cs
@@ -7,7 +7,7 @@ using Photon.Pun;
 public class PlayerInfoList
 {
     private List<PlayerInfo> players = new List<PlayerInfo>();
-    private List<PlayerInfo> winners = new List<PlayerInfo>();
+    private PlayerInfo winner = null;
     private PlayerInfo attacker = null;
 
     public void Add(int actorNumber)
@@ -33,11 +33,14 @@ public class PlayerInfoList
 
     public void DecideChallengeWinners(int potCoins)
     {
+        winner = null;
         List<PlayerInfo> challengers = players.FindAll(player => player.IsChallengeSuccess(potCoins));
         if (challengers.Count == 0) return;
 
         int winnerAmount = challengers.Max(player => player.challengeAmount);
-        winners = challengers.FindAll(player => player.challengeAmount == winnerAmount);
+        List<PlayerInfo> winners = challengers.FindAll(player => player.challengeAmount == winnerAmount);
+        if (winners.Count != 1) return;
+        winner = winners.First();
     }
 
     public void DecideAttackWinner()
@@ -69,9 +72,9 @@ public class PlayerInfoList
         return players.Count;
     }
 
-    public List<PlayerInfo> GetChallengeWinners()
+    public PlayerInfo GetChallengeWinner()
     {
-        return winners;
+        return winner;
     }
 
     public PlayerInfo GetAttackWinner()

--- a/Assets/Scripts/Gamble/PlayerInfoList.cs
+++ b/Assets/Scripts/Gamble/PlayerInfoList.cs
@@ -22,12 +22,12 @@ public class PlayerInfoList
 
     public bool EveryDecided()
     {
-        return players.TrueForAll(player => player.IsDecide());
+        return players.TrueForAll(player => player.IsDecided());
     }
 
     public void ChangeUndecidedPlayerToShare()
     {
-        players.FindAll(player => player.isLive && !player.IsDecide())
+        players.FindAll(player => player.isLive && !player.IsDecided())
             .ForEach(player => player.ChoiceShare());
     }
 

--- a/Assets/Scripts/Gamble/PlayerInfoList.cs
+++ b/Assets/Scripts/Gamble/PlayerInfoList.cs
@@ -34,6 +34,8 @@ public class PlayerInfoList
     public void DecideChallengeWinners(int potCoins)
     {
         List<PlayerInfo> challengers = players.FindAll(player => player.IsChallengeSuccess(potCoins));
+        if (challengers.Count == 0) return;
+
         int winnerAmount = challengers.Max(player => player.challengeAmount);
         winners = challengers.FindAll(player => player.challengeAmount == winnerAmount);
     }
@@ -43,6 +45,7 @@ public class PlayerInfoList
         attacker = null;
         List<PlayerInfo> attackers = players.FindAll(player => player.IsAttack());
         if (attackers.Count != 1) return;
+
         attacker = attackers.First();
     }
 

--- a/Assets/Scripts/Gamble/PlayerInfoList.cs.meta
+++ b/Assets/Scripts/Gamble/PlayerInfoList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53674cf610988c34b98e65abe2069f3a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -26,7 +26,7 @@ public class UIManager : MonoBehaviour
     }
     void SetTextUI()
     {
-        PlayerInfo player = GambleManager.localPlayerInfo;
+        PlayerInfo player = GambleManager.GetMyInfo();
         timeText.text = ((int)GambleManager.leftTime).ToString();
         SetText(playerInfoText.transform.Find("ChoiceText").gameObject, player.choice.ToString());
         SetText(playerInfoText.transform.Find("ChallengeAmountText").gameObject, player.challengeAmount.ToString());


### PR DESCRIPTION
## 정상국은 필히 확인하도록

코드밖에 건든 거 없어서 여기서 filed changed 확인해도 됨
아님 pull 받아서 보든지는 편하신대루

`PlayerInfoList `클래스를 만들어 각 기능을 명확하게 함수명으로 볼 수 있도록 함
- `Reset`: 모든 플레이어 리셋
- `EveryDecided`: 모든 플레이어가 선택했는지 확인
- `ChangeUndecidedPlayerToShare`: 선택하지 않은 플레이어 모두 share로 바꿈
- `DecideChallengeWinners`: 승자 확인
- `DecideAttackWinner`: 어택커 확인
- `ShareCoins`: 코인을 share 고른 사람들끼리 나눠갖도록 함
- `GetMine`: `PhotonNetwork.LocalPlayer.ActorNumber`랑 비교해서 찾음

`PlayerInfo` 내에서 데이터를 처리하도록 함. 외부에서는 get만 가능. set 불가능.

`GambleManager` 함수 순서 좀 바꿈. 위에서 아래로 쭉 읽을 수 있도록